### PR TITLE
Potential fix for code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/examples/handler.py
+++ b/examples/handler.py
@@ -3,7 +3,7 @@ from aiohttp import web
 from navigator import Application
 from navigator.background import BackgroundQueue, TaskWrapper
 from app import Main
-
+import logging
 
 async def blocking_code(*args, **kwargs):
     print('Starting blocking code')
@@ -30,8 +30,8 @@ async def handle(request):
         text = "Queue is full, please try again later."
         print(text)
     except Exception as e:
-        text = f"An error occurred: {str(e)}"
-        print(text)
+        logging.exception("Exception occurred while handling request")
+        text = "An internal error has occurred."
     return web.Response(text=text)
 
 app = Application()
@@ -46,6 +46,7 @@ app.add_routes([web.get('/', handle),
                 web.get('/{name}', handle)])
 
 
+    logging.basicConfig(level=logging.INFO)
 if __name__ == '__main__':
     try:
         app.run()


### PR DESCRIPTION
Potential fix for [https://github.com/phenobarbital/navigator/security/code-scanning/14](https://github.com/phenobarbital/navigator/security/code-scanning/14)

To fix the problem, we should avoid exposing the exception message to the user. Instead, we should log the exception details (including the stack trace) on the server for debugging purposes, and return a generic error message to the user. This can be achieved by importing the `logging` module, logging the exception using `logging.exception()`, and setting `text` to a generic message such as "An internal error has occurred." in the `except Exception as e` block. Only the code in `examples/handler.py` needs to be changed, specifically the `except Exception as e` block in the `handle` function. We also need to ensure that the `logging` module is imported and, optionally, configure basic logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
