### PR TITLE
fix(server): stop forwarding invalid kwargs to aiohttp RequestHandler

### DIFF
--- a/navigator/navigator.py
+++ b/navigator/navigator.py
@@ -602,12 +602,23 @@ class Application(BaseApplication):
         port = port or self.port
 
         try:
+            # ``AppRunner`` forwards any extra kwargs to aiohttp's
+            # ``Server``/``RequestHandler``. ``client_timeout`` and
+            # ``max_request_size`` are NOT valid ``RequestHandler`` arguments,
+            # so passing them raised a ``TypeError`` that aiohttp swallowed,
+            # logging "Failed to create request handler with custom kwargs ...
+            # falling back to filtered kwargs" and silently dropping *every*
+            # custom setting. Only forward kwargs ``RequestHandler`` accepts.
             runner_kwargs = {
                 'handle_signals': handle_signals,
                 'keepalive_timeout': kwargs.get('keepalive_timeout', 30),
-                'client_timeout': kwargs.get('client_timeout', 60),
-                'max_request_size': kwargs.get('max_request_size', 1024**2),
             }
+            # The body-size limit belongs to the ``Application``
+            # (``client_max_size``), not to the request handler. Apply it to
+            # the app before the runner is set up.
+            max_request_size = kwargs.get('max_request_size', 1024**2)
+            if max_request_size is not None:
+                app._client_max_size = int(max_request_size)
             # Only add these if they're explicitly provided (not None)
             if 'access_log_class' in kwargs and kwargs['access_log_class'] is not None:
                 runner_kwargs['access_log_class'] = kwargs['access_log_class']
@@ -677,6 +688,12 @@ class Application(BaseApplication):
             if unix_path.exists():
                 unix_path.unlink()
                 self.logger.debug(f"Removed existing socket: {unix_path}")
+
+            # Body-size limit belongs to the ``Application``
+            # (``client_max_size``), not to the request handler.
+            max_request_size = kwargs.get('max_request_size', 1024**2)
+            if max_request_size is not None:
+                app._client_max_size = int(max_request_size)
 
             # Create and setup runner
             self._runner = web.AppRunner(


### PR DESCRIPTION
## Problem

Starting a Navigator server logs this warning on the first request:

```
[WARNING] aiohttp.server(web_server.py:85) :: Failed to create request handler
with custom kwargs {'keepalive_timeout': 30, 'client_timeout': 60,
'max_request_size': 1048576, 'debug': False,
'access_log_class': <class 'aiohttp.web_log.AccessLogger'>},
falling back to filtered kwargs. This may indicate a misconfiguration.
```

### Root cause

`_run_tcp` builds `runner_kwargs` including `client_timeout` and
`max_request_size` and passes them to `web.AppRunner`. `AppRunner` forwards
unknown kwargs to aiohttp's `Server` → `RequestHandler`. **Neither
`client_timeout` nor `max_request_size` is a valid `RequestHandler`
argument**, so construction raises `TypeError`. aiohttp catches it in its
failsafe path (`web_server.py:74-91`), logs the warning, and rebuilds the
handler keeping only `debug`/`access_log_class`.

Net effect: the warning is noisy **and** every custom setting is silently
dropped — `client_timeout` and `max_request_size` never take effect.

## Fix

- Forward to `AppRunner` only the kwargs `RequestHandler` actually accepts
  (`keepalive_timeout`, `access_log*`). `client_timeout` has no server-side
  equivalent in aiohttp and is removed.
- Apply `max_request_size` where it belongs — the `Application` body-size
  limit (`client_max_size`) — in **both** `_run_tcp` and `_run_unix`, so the
  limit is honored instead of ignored.

## Verification

- `python -m py_compile navigator/navigator.py` passes.
- Reproduced against aiohttp by spinning an `AppRunner` with the new kwarg
  set + a real TCP connection: the "falling back to filtered kwargs" warning
  **no longer fires**, and `app._client_max_size` is set to the configured
  value.

Affects 3.0.x–3.1.1 (current `master`).