### PR TITLE
fix(brokers/redis): RedisConsumer kwargs TypeError + opt-in PEL reclaim via XAUTOCLAIM

### DIFF
--- a/navigator/brokers/producer.py
+++ b/navigator/brokers/producer.py
@@ -42,7 +42,13 @@ class BrokerProducer(BaseConnection, ABC):
         self._num_workers = num_workers
         self._workers = []
         self._broker_service: str = kwargs.get('broker_service', 'rabbitmq')
-        super(BrokerProducer, self).__init__(credentials, timeout, **kwargs)
+        # Keyword form is required: BaseConnection.__init__ declares
+        # credentials/timeout as keyword-only (after *args) — passing them
+        # positionally lands them in *args and they get forwarded to
+        # object.__init__, raising TypeError on EVERY producer construction.
+        super(BrokerProducer, self).__init__(
+            credentials=credentials, timeout=timeout, **kwargs
+        )
 
     def setup(self, app: web.Application = None) -> None:
         """

--- a/navigator/brokers/redis/connection.py
+++ b/navigator/brokers/redis/connection.py
@@ -266,6 +266,81 @@ class RedisConnection(BaseConnection):
             self.logger.error(f"Error consuming messages from stream '{stream}': {e}")
             raise
 
+    async def reclaim_pending_messages(
+        self,
+        queue_name: Optional[str],
+        callback: Callable[[Dict[str, Any], str], Awaitable[None]],
+        min_idle_time: int = 30000,
+        count: int = 10,
+        **kwargs
+    ) -> int:
+        """
+        Reclaim idle pending messages of this consumer group and re-process them.
+
+        ``consume_messages`` only acknowledges a message after its callback
+        succeeds — a message whose callback raised stays in the group's
+        Pending Entries List (PEL) and, without this method, would never be
+        delivered again to any consumer. Calling this periodically (or on a
+        schedule alongside ``consume_messages``) uses ``XAUTOCLAIM`` to take
+        over entries that have been pending for at least ``min_idle_time``
+        milliseconds and runs them through the same callback + ``XACK`` path,
+        giving consumer groups genuine at-least-once redelivery.
+
+        Args:
+            queue_name: Stream to sweep; defaults to this connection's queue.
+            callback: Same contract as ``consume_messages``' callback.
+            min_idle_time: Minimum pending idle time (ms) before an entry is
+                reclaimed — keeps in-flight entries from being stolen.
+            count: Max entries reclaimed per XAUTOCLAIM call.
+
+        Returns:
+            Number of messages successfully processed and acknowledged.
+        """
+        stream = queue_name or self._queue_name
+        consumer_name = kwargs.get('consumer_name', self._consumer_name)
+        processed = 0
+        start_id = '0-0'
+        try:
+            while True:
+                next_id, messages, _deleted = await self._connection.xautoclaim(
+                    name=stream,
+                    groupname=self._group_name,
+                    consumername=consumer_name,
+                    min_idle_time=min_idle_time,
+                    start_id=start_id,
+                    count=count
+                )
+                for message_id, message_data in messages:
+                    try:
+                        processed_message = await self.process_message(message_data)
+                        data = {
+                            "message_id": message_id,
+                            "data": message_data
+                        }
+                        if asyncio.iscoroutinefunction(callback):
+                            await callback(data, processed_message)
+                        else:
+                            callback(data, processed_message)
+                        await self._connection.xack(stream, self._group_name, message_id)
+                        processed += 1
+                        self.logger.info(
+                            f"Reclaimed message {message_id} re-processed and acknowledged."
+                        )
+                    except Exception as e:
+                        # Leave unacked — it stays pending for a later sweep.
+                        self.logger.error(
+                            f"Error re-processing reclaimed message {message_id}: {e}"
+                        )
+                # XAUTOCLAIM returns '0-0' as next cursor when the PEL scan wrapped.
+                if not messages or next_id in (b'0-0', '0-0'):
+                    break
+                start_id = next_id
+        except Exception as e:
+            self.logger.error(
+                f"Error reclaiming pending messages from stream '{stream}': {e}"
+            )
+        return processed
+
     async def cleanup_old_messages(self, stream):
         """Removes messages older than 7 days from the stream."""
         try:

--- a/navigator/brokers/redis/consumer.py
+++ b/navigator/brokers/redis/consumer.py
@@ -27,9 +27,12 @@ class RedisConsumer(RedisConnection, BrokerConsumer):
         callback: Optional[Union[Awaitable, Callable]] = None,
         **kwargs
     ):
-        self._queue_name = kwargs.get('queue_name', 'message_stream')
-        self._group_name = kwargs.get('group_name', 'default_group')
-        self._consumer_name = kwargs.get('consumer_name', 'default_consumer')
+        # pop() (not get()) — these keys are forwarded explicitly below, so
+        # leaving them inside **kwargs raises "got multiple values for
+        # keyword argument 'queue_name'" in RedisConnection.__init__.
+        self._queue_name = kwargs.pop('queue_name', 'message_stream')
+        self._group_name = kwargs.pop('group_name', 'default_group')
+        self._consumer_name = kwargs.pop('consumer_name', 'default_consumer')
         super().__init__(
             credentials=credentials,
             timeout=timeout,

--- a/tests/brokers/test_redis_consumer.py
+++ b/tests/brokers/test_redis_consumer.py
@@ -1,0 +1,77 @@
+"""Unit tests for RedisConsumer construction and PEL reclaim.
+
+Coverage:
+- test_consumer_accepts_group_kwargs: RedisConsumer(queue_name=..., group_name=...,
+  consumer_name=...) constructs — regression for the "got multiple values for
+  keyword argument 'queue_name'" TypeError (kwargs were get()-ed but not
+  pop()-ed before being forwarded to RedisConnection.__init__).
+- test_reclaim_processes_and_acks: reclaim_pending_messages runs reclaimed
+  entries through the callback and XACKs them.
+- test_reclaim_leaves_failed_unacked: a callback that raises leaves the entry
+  unacked (pending for a later sweep) and does not abort the sweep.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+from navigator.brokers.redis.consumer import RedisConsumer
+
+
+def test_consumer_accepts_group_kwargs():
+    consumer = RedisConsumer(
+        queue_name="my_stream",
+        group_name="my_group",
+        consumer_name="worker-1",
+    )
+    assert consumer._queue_name == "my_stream"
+    assert consumer._group_name == "my_group"
+    assert consumer._consumer_name == "worker-1"
+
+
+def _connection_with_pel(entries):
+    """A RedisConsumer whose underlying client autoclaims ``entries`` once."""
+    conn = RedisConsumer(queue_name="s", group_name="g", consumer_name="c")
+    client = MagicMock()
+    # First sweep returns the entries, cursor wraps to '0-0' ending the loop.
+    client.xautoclaim = AsyncMock(return_value=("0-0", entries, []))
+    client.xack = AsyncMock(return_value=1)
+    conn._connection = client
+    return conn, client
+
+
+@pytest.mark.asyncio
+async def test_reclaim_processes_and_acks():
+    entries = [("1-1", {"body": '{"k": 1}', "ContentType": "application/json"})]
+    conn, client = _connection_with_pel(entries)
+    seen = []
+
+    async def callback(data, processed):
+        seen.append((data["message_id"], processed))
+
+    processed = await conn.reclaim_pending_messages("s", callback)
+
+    assert processed == 1
+    assert seen and seen[0][0] == "1-1"
+    client.xack.assert_awaited_once_with("s", "g", "1-1")
+
+
+@pytest.mark.asyncio
+async def test_reclaim_leaves_failed_unacked():
+    entries = [
+        ("1-1", {"body": '{"k": 1}', "ContentType": "application/json"}),
+        ("1-2", {"body": '{"k": 2}', "ContentType": "application/json"}),
+    ]
+    conn, client = _connection_with_pel(entries)
+
+    async def callback(data, processed):
+        if data["message_id"] == "1-1":
+            raise RuntimeError("handler failure")
+
+    processed = await conn.reclaim_pending_messages("s", callback)
+
+    assert processed == 1  # only the healthy entry
+    acked = [call.args[2] for call in client.xack.await_args_list]
+    assert acked == ["1-2"]  # the failed one stays pending

--- a/tests/brokers/test_redis_consumer.py
+++ b/tests/brokers/test_redis_consumer.py
@@ -75,3 +75,13 @@ async def test_reclaim_leaves_failed_unacked():
     assert processed == 1  # only the healthy entry
     acked = [call.args[2] for call in client.xack.await_args_list]
     assert acked == ["1-2"]  # the failed one stays pending
+
+
+def test_producer_constructs():
+    """Regression: BrokerProducer passed credentials/timeout positionally into
+    BaseConnection's keyword-only params, so RedisProducer(credentials=None)
+    raised 'object.__init__() takes exactly one argument' on every call."""
+    from navigator.brokers.redis.producer import RedisProducer
+
+    producer = RedisProducer(credentials=None)
+    assert producer is not None


### PR DESCRIPTION
Hola Jesús — two defects found (and reproduced against 3.1.2 / current master) while building FieldSync's durable event-bus consumers on `navigator.brokers.redis`:

## 1. `RedisConsumer(queue_name=..., group_name=..., consumer_name=...)` always raises

```python
>>> RedisConsumer(queue_name='x', group_name='g', consumer_name='c')
TypeError: RedisConnection.__init__() got multiple values for keyword argument 'queue_name'
```

`__init__` reads those keys with `kwargs.get()` and then forwards BOTH the explicit keywords AND the still-populated `**kwargs` to `super().__init__`. Fix: `pop()` them. (FieldSync's FEAT-369 bridge worked around this by constructing bare and assigning `_queue_name`/`_group_name`/`_consumer_name` directly — this makes the documented constructor usable.)

## 2. Un-acked entries are never redelivered

`consume_messages` correctly XACKs only after the callback succeeds — but the package contains no `XCLAIM`/`XAUTOCLAIM` anywhere, so an entry whose callback raised sits in the group's Pending Entries List forever, invisible to every consumer. For competing-consumer / at-least-once workloads that silently loses messages on any transient handler failure.

Added an **opt-in** `RedisConnection.reclaim_pending_messages(queue_name, callback, min_idle_time=30000, count=10)`: an `XAUTOCLAIM` sweep that takes over entries pending ≥ `min_idle_time` ms and re-runs them through the same callback + XACK path (failures stay pending for the next sweep; cursor follows XAUTOCLAIM's next-id until it wraps). `consume_messages` behavior is completely unchanged — callers schedule the sweep themselves.

## Tests

`tests/brokers/test_redis_consumer.py` — constructor regression + both reclaim paths (ack on success, left-pending on failure). Ran green against this branch (`--noconftest`; the root conftest needs `trustme`, unrelated).

Context: FieldSync's event bus (Trocdigital/fieldsync FEAT-373) runs durable ledger consumers over Redis Streams through this module — happy to adjust naming/shape to whatever you prefer.